### PR TITLE
Make url_str regex more general

### DIFF
--- a/procyclingstats/utils.py
+++ b/procyclingstats/utils.py
@@ -14,7 +14,7 @@ class reg: # pylint: disable=invalid-name
     """
     base_url = "(https:\\/\\/www.procyclingstats.com\\/+)"
     """example match `https://www.procyclingstats.com/`"""
-    url_str = "(\\/+([a-zA-Z]+-)*([a-zA-Z]+))"
+    url_str = "(\\/+([a-zA-Z0-9]+-)*([a-zA-Z0-9]+))"
     """example match `/This-is-url-StriNg`"""
     year = "(\\/+\\d{4})"
     """example match `/1111`"""


### PR DESCRIPTION
Hi @themm1 , it's me again 😄 

I had an issue trying to parse the results for E3 Harelbeke:

```python
from procyclingstats import Stage
Stage('race/e3-harelbeke/2019')
# ValueError: Given URL is indvalid: 'race/e3-harelbeke/2019'
```

I think adding numeric digits to the regex used to validate race URLs might fix the issue. I haven't tested this change or considered whether it would break any other validation regexes.

Would appreciate it if you could test this, and/or figure out another solution if this doesn't fix the problem!