### PR TITLE
added check for uci / pcs points inside the lambda

### DIFF
--- a/procyclingstats/table_parser.py
+++ b/procyclingstats/table_parser.py
@@ -310,7 +310,7 @@ class TableParser:
     def uci_points(self) -> List[Optional[float]]:
         try:
             return self.parse_extra_column("UCI",
-                lambda x: float(x) if x else 0)
+                lambda x: float(x) if x and x.replace('.', '', 1).isdigit() else 0)
         except ValueError:
             return [0 for _ in range(self.table_length)]
 
@@ -320,7 +320,7 @@ class TableParser:
         except ValueError:
             try:
                 return self.parse_extra_column("PCS points",
-                    lambda x: int(x) if x else 0)
+                    lambda x: int(x) if x  and x.isdigit() else 0)
             except ValueError:
                 return [0 for _ in range(self.table_length)]
 


### PR DESCRIPTION
Might have been a change to how rows with no UCI/PCS points were shown - if there was a single row with no points, the error thrown would exit the lambda and return a full list of 0s