### PR TITLE
Update bike field location in team scraper

### DIFF
--- a/procyclingstats/team_scraper.py
+++ b/procyclingstats/team_scraper.py
@@ -79,7 +79,7 @@ class Team(Scraper):
         :return: Bike brand e.g. ``Specialized``.
         """
         bike_html = self.html.css_first(
-            "div > ul.infolist > li:nth-child(3) > div:nth-child(2)")
+            "div > ul.infolist > li:nth-child(4) > div:nth-child(2)")
         return bike_html.text()
 
     def wins_count(self) -> int:


### PR DESCRIPTION
When getting a team, the `bike` field has the wrong value.

```py
from procyclingstats import Team

team = Team("team/uae-team-emirates-2023")
print(team.bike())
```

This printed `United Arab Emirates` instead of `Colnago`.

This change solves this issue.