### PR TITLE
Added '-' case to wins_count() so it returns 0 instead of throwing an error

### DIFF
--- a/procyclingstats/team_scraper.py
+++ b/procyclingstats/team_scraper.py
@@ -82,14 +82,20 @@ class Team(Scraper):
             "div > ul.infolist > li:nth-child(4) > div:nth-child(2)")
         return bike_html.text()
 
-    def wins_count(self) -> int:
+    def wins_count(self) -> Optional[int]:
         """
         Parses count of wins in corresponding season from HTML.
 
         :return: Count of wins in corresponding season.
         """
         wins_count_html = self.html.css_first(".team-kpi > li.nr")
-        return int(wins_count_html.text())
+        wins_count_text = str(wins_count_html.text())
+        if wins_count_text.isdigit():
+            return int(wins_count_text)
+        elif wins_count_text == '-':
+            return 0
+        else:
+            return None
     
     def pcs_points(self) -> Optional[int]:
         """


### PR DESCRIPTION
wins_count() located in team_scraper.py assumed the scraped html was a valid integer, but sometimes it would be a dash. I just added a case to return 0--upon checking procyclingstats.com that seems to be the intended meaning behind a dash showing up there. This corresponds with the issue I created: #30 