### PR TITLE
feat: startlist (for stage and race)

### DIFF
--- a/procyclingstats/race_scraper.py
+++ b/procyclingstats/race_scraper.py
@@ -1,5 +1,6 @@
 import re
 from typing import Any, Dict, List
+from selectolax.parser import HTMLParser
 
 from .errors import ExpectedParsingError, UnexpectedParsingError
 from .scraper import Scraper
@@ -117,6 +118,30 @@ class Race(Scraper):
         startdate_html = self.html.css_first(
             ".list > li > div:nth-child(2)")
         return startdate_html.text()
+
+
+    def startlist(self) -> List[str]:
+        """
+        Parses the startlist from the HTML.
+
+        :return: List of rider names
+        """
+        import requests
+
+        riders: List[str] = []
+
+        res = requests.get(self.url + "/startlist/alphabetical").text
+        html = HTMLParser(res)
+
+        for i in range(1,300):
+            res = html.css_first(f"tr:nth-of-type({i}) td > a[href]:nth-of-type(1)")
+            if res == None: break
+            if temp := res.attrs["href"]: riders.append(temp)
+            # v if name should be formatted better
+            # if temp := res.text(): riders.append(temp)
+
+        return riders
+
 
     def enddate(self) -> str:
         """

--- a/tests/startlists.py
+++ b/tests/startlists.py
@@ -1,0 +1,14 @@
+from procyclingstats.stage_scraper import Stage
+from procyclingstats.race_scraper import Race
+
+# non empty list
+assert([] != Stage("race/giro-d-italia/2021/stage-1").startlist())
+assert([] != Stage("race/giro-d-italia/2025/stage-9").startlist())
+assert([] != Stage("race/tour-de-france/2024/").startlist())
+assert([] != Race("race/paris-roubaix/2025").startlist())
+
+# standard output
+print(Stage("race/giro-d-italia/2021/stage-1").startlist())
+print(Stage("race/giro-d-italia/2025/stage-9").startlist())
+print(Stage("race/tour-de-france/2024/").startlist())
+print(Race("race/paris-roubaix/2025").startlist())


### PR DESCRIPTION
I'm guessing this code is better written with the library functions, but I couldn't figure it out. I am hoping a better way might be obvious to you.
```python
import requests

riders: List[str] = []

res = requests.get(self.url + "/startlist/alphabetical").text
html = HTMLParser(res)
```

Also, fallback here could be None, so the very awesome 🦭-operator is perfect 😎.
```python
if not categories:
    fallback = self.html.css('.general > table.results')
if fallback:
    categories = [fallback[0]]
else: ...
 ```