### PR TITLE
New data on Stage.climbs()

### DIFF
--- a/procyclingstats/stage_scraper.py
+++ b/procyclingstats/stage_scraper.py
@@ -227,8 +227,8 @@ class Stage(Scraper):
       
     def climbs(self, *args: str) -> List[Dict[str, Any]]:
         """
-        Parses KOM classification results table from HTML. When KOM classif. is
-        unavailable empty list is returned.
+        Parses listed climbs from the stage. When climbs aren't listed returns
+        empty list.
 
         :param args: Fields that should be contained in returned table. When
             no args are passed, all fields are parsed.


### PR DESCRIPTION
Retrieving more data on the climbs section of the stage with scraping the Kom/today.

This allows use to get the official climb's category (HC, 1, 2,3 4), and the climb's ranking (for each rider earning points we have general info, the rank and the points earned).

We could also add the 'km_before_finnish' but already available in race_climbs_scrapper.py. 

Because there is a list inside the function (the rank field), a practice that isn't common in this project, I'm interested if you find a better way to do it. 