### PR TITLE
Optional pulling removed (doping) ranks

### DIFF
--- a/procyclingstats/rider_results_scraper.py
+++ b/procyclingstats/rider_results_scraper.py
@@ -89,6 +89,8 @@ class RiderResults(Scraper):
             - nationality: Nationality of the stage race.
             - date: Date when the stage occured in ``YYYY-MM-DD`` format.
             - rank: Rider's result in the stage.
+            - removed_rank: Original rank of a removed/disqualified rider.
+                Opt-in field: only returned when explicitly requested.
             - class: Class of the stage's race, e.g. ``2.UWT``.
             - pcs_points:
             - uci_points:
@@ -133,6 +135,8 @@ class RiderResults(Scraper):
             - nationality: Nationality of the stage race.
             - date: Date when the stage occured in ``YYYY-MM-DD`` format.
             - rank: Rider's result in the stage.
+            - removed_rank: Original rank of a removed/disqualified rider.
+                Opt-in field: only returned when explicitly requested.
             - class: Class of the stage's race, e.g. ``2.UWT``.
             - vertical_meters: Vertical meters gained in final n KMs.
             - average_percentage: Average percentage of last n KMs.

--- a/procyclingstats/stage_scraper.py
+++ b/procyclingstats/stage_scraper.py
@@ -366,6 +366,8 @@ class Stage(Scraper):
             - team_name:
             - team_url:
             - rank: Rider's result in the stage.
+            - removed_rank: Original rank of a removed/disqualified rider.
+                Opt-in field: only returned when explicitly requested.
             - status: ``DF``, ``DNF``, ``DNS``, ``OTL`` or ``DSQ``.
             - age: Rider's age.
             - nationality: Rider's nationality as 2 chars long country code.
@@ -466,6 +468,8 @@ class Stage(Scraper):
             - team_name:
             - team_url:
             - rank: Rider's GC rank after the stage.
+            - removed_rank: Original rank of a removed/disqualified rider.
+                Opt-in field: only returned when explicitly requested.
             - prev_rank: Rider's GC rank before the stage.
             - age: Rider's age.
             - nationality: Rider's nationality as 2 chars long country code.
@@ -515,6 +519,8 @@ class Stage(Scraper):
             - team_name:
             - team_url:
             - rank: Rider's points classif. rank after the stage.
+            - removed_rank: Original rank of a removed/disqualified rider.
+                Opt-in field: only returned when explicitly requested.
             - prev_rank: Rider's points classif. rank before the stage.
             - points: Rider's points classif. points after the stage.
             - age: Rider's age.
@@ -562,6 +568,8 @@ class Stage(Scraper):
             - team_name:
             - team_url:
             - rank: Rider's KOM classif. rank after the stage.
+            - removed_rank: Original rank of a removed/disqualified rider.
+                Opt-in field: only returned when explicitly requested.
             - prev_rank: Rider's KOM classif. rank before the stage.
             - points: Rider's KOM points after the stage.
             - age: Rider's age.
@@ -609,6 +617,8 @@ class Stage(Scraper):
             - team_name:
             - team_url:
             - rank: Rider's youth classif. rank after the stage.
+            - removed_rank: Original rank of a removed/disqualified rider.
+                Opt-in field: only returned when explicitly requested.
             - prev_rank: Rider's youth classif. rank before the stage.
             - time: Rider's GC time after the stage.
             - age: Rider's age.
@@ -652,6 +662,8 @@ class Stage(Scraper):
             - team_name:
             - team_url:
             - rank: Teams's classif. rank after the stage.
+            - removed_rank: Original rank of a removed/disqualified team.
+                Opt-in field: only returned when explicitly requested.
             - prev_rank: Team's classif. rank before the stage.
             - time: Team's total GC time after the stage.
             - nationality: Team's nationality as 2 chars long country code.

--- a/procyclingstats/table_parser.py
+++ b/procyclingstats/table_parser.py
@@ -73,6 +73,7 @@ class TableParser:
 
         :fields options for tables with a header:
             - rank
+            - removed_rank
             - status
             - prev_rank
             - pcs_points
@@ -357,6 +358,30 @@ class TableParser:
             try:
                 return self.parse_extra_column(column_name,
                     lambda x: int(x) if x.isnumeric() else None)
+            except ValueError:
+                pass
+        raise ValueError("Rank column wasn't found.")
+
+    def removed_rank(self) -> List[Optional[int]]:
+        """Parses rank values for results that have been removed (struck
+        through). Returns the rank as int if removed, None otherwise."""
+        possible_columns = ["Rnk", "pos", "Result", "#"]
+        for column_name in possible_columns:
+            try:
+                index = self._get_column_index_from_header(column_name)
+                elements = self.html_table.css(
+                    f"{self.table_row_tag} > {self.row_column_tag}"
+                    f":nth-child({index + 1})")
+                results = []
+                for e in elements:
+                    s_tag = e.css_first("s")
+                    if s_tag:
+                        cleaned = s_tag.text().replace('\xa0', '').strip()
+                        results.append(
+                            int(cleaned) if cleaned.isnumeric() else None)
+                    else:
+                        results.append(None)
+                return results
             except ValueError:
                 pass
         raise ValueError("Rank column wasn't found.")

--- a/procyclingstats/utils.py
+++ b/procyclingstats/utils.py
@@ -190,6 +190,9 @@ def join_tables(table1: List[Dict[str, Any]],
             table.append({**table2_dict[row[join_key]], **row})
     return table
 
+OPT_IN_FIELDS = ("removed_rank",)
+
+
 def parse_table_fields_args(args: Tuple[str],
                             available_fields: Tuple[str, ...]) -> List[str]:
     """
@@ -202,7 +205,7 @@ def parse_table_fields_args(args: Tuple[str],
     fields.
     """
     for arg in args:
-        if arg not in available_fields:
+        if arg not in available_fields and arg not in OPT_IN_FIELDS:
             raise ValueError("Invalid field argument")
     if args:
         return list(args)


### PR DESCRIPTION
Current behavior is that people who have lost their results get null for ranks in their races. On PCS, they have ranks crossed through. In some cases, it can be useful to have these ranks - eg when comparing the viewer experience across eras, I want to factor in USPS's dominance, as at the time they were winning a lot of races. 

This update adds 'removed_rank' as an optional field to the parser. You have to specify it, if you do a parse with no arguments it won't be included. This should make the update backwards compatible.